### PR TITLE
Use isobject to check obj type.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,14 @@
 
 'use strict';
 
-var typeOf = require('kind-of');
+var isobject = require('isobject');
 var isDescriptor = require('is-descriptor');
 var define = (typeof Reflect !== 'undefined' && Reflect.defineProperty)
   ? Reflect.defineProperty
   : Object.defineProperty;
 
 module.exports = function defineProperty(obj, key, val) {
-  if (typeOf(obj) !== 'object' && typeof obj !== 'function' && !Array.isArray(obj)) {
+  if (!isobject(obj) && typeof obj !== 'function' && !Array.isArray(obj)) {
     throw new TypeError('expected an object, function, or array');
   }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "is-descriptor": "^1.0.2",
-    "kind-of": "^6.0.2"
+    "isobject": "^3.0.1"
   },
   "devDependencies": {
     "gulp-format-md": "^1.0.0",

--- a/test.js
+++ b/test.js
@@ -56,6 +56,38 @@ describe('define', function() {
     assert.equal(fixture.foo, 'baz');
   });
 
+  it('should define a property on an array', function() {
+    var fixture = [];
+    fixture.bar = 'baz';
+    define(fixture, 'foo', {
+      configurable: true,
+      set: function(key) {
+        define(this, '_val', this[key]);
+      },
+      get: function() {
+        return this._val;
+      }
+    });
+    fixture.foo = 'bar';
+    assert.equal(fixture.foo, 'baz');
+  });
+
+  it('should define a property on an error', function() {
+    var fixture = new Error('fixture error');
+    fixture.bar = 'baz';
+    define(fixture, 'foo', {
+      configurable: true,
+      set: function(key) {
+        define(this, '_val', this[key]);
+      },
+      get: function() {
+        return this._val;
+      }
+    });
+    fixture.foo = 'bar';
+    assert.equal(fixture.foo, 'baz');
+  });
+
   it('should define a property with data descriptors:', function() {
     var obj = {};
     define(obj, 'foo', {


### PR DESCRIPTION
This PR uses `isobject` as suggested in #1 to allow any type of object to be passed in. My specific use case was for adding non-enumerable properties to instances of `Error`.

This PR also adds tests for `array` and `error`.