### PR TITLE
Update is-descriptor to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "test": "mocha"
   },
   "dependencies": {
-    "is-descriptor": "^1.0.2",
+    "is-descriptor": "^3.0.0",
     "isobject": "^3.0.1"
   },
   "devDependencies": {
     "gulp-format-md": "^1.0.0",
-    "mocha": "^3.5.3"
+    "mocha": "^7.1.0"
   },
   "keywords": [
     "define",

--- a/test.js
+++ b/test.js
@@ -29,6 +29,7 @@ describe('define', function() {
     var obj = {bar: 'baz'};
     define(obj, 'foo', {
       configurable: true,
+      enumerable: false,
       get: function() {
         return this._val;
       },
@@ -45,6 +46,7 @@ describe('define', function() {
     fixture.bar = 'baz';
     define(fixture, 'foo', {
       configurable: true,
+      enumerable: false,
       set: function(key) {
         define(this, '_val', this[key]);
       },
@@ -61,6 +63,7 @@ describe('define', function() {
     fixture.bar = 'baz';
     define(fixture, 'foo', {
       configurable: true,
+      enumerable: false,
       set: function(key) {
         define(this, '_val', this[key]);
       },
@@ -77,6 +80,7 @@ describe('define', function() {
     fixture.bar = 'baz';
     define(fixture, 'foo', {
       configurable: true,
+      enumerable: false,
       set: function(key) {
         define(this, '_val', this[key]);
       },
@@ -91,6 +95,8 @@ describe('define', function() {
   it('should define a property with data descriptors:', function() {
     var obj = {};
     define(obj, 'foo', {
+      configurable: false,
+      enumerable: false,
       writable: true,
       value: 'bar'
     });


### PR DESCRIPTION
Version ^1.0.2 of `is-descriptor` currently being used depends on a library with a vulnerability as described [here](https://www.npmjs.com/advisories/1490). 

This PR updates the dependency to its latest version which no longer depends on the aforementioned library, and updates the test code to adhere to the latest specification which requires both `configurable` and `enumerable` to be defined to be recognized as a valid descriptor.

While at it, I also updated `mocha` to the latest version to resolve `npm audit` vulnerabilities.